### PR TITLE
fix: Remove key field and field directive validation

### DIFF
--- a/src/Types/EntityObjectType.php
+++ b/src/Types/EntityObjectType.php
@@ -54,9 +54,6 @@ class EntityObjectType extends ObjectType
      */
     public function __construct(array $config)
     {
-        self::validateFields($config);
-        self::validateKeyFields($config);
-
         $this->keyFields = $config['keyFields'];
 
         if (isset($config['__resolveReference'])) {
@@ -119,52 +116,6 @@ class EntityObjectType extends ObjectType
         $refContainsKeys = count(array_intersect($this->getKeyFields(), $refKeys)) === count($this->getKeyFields());
 
         Utils::invariant($refContainsKeys, 'Key fields are missing from the entity reference.');
-    }
-
-    private static function validateFields(array $config)
-    {
-        if (is_callable($config['fields'])) {
-            $fields = $config['fields']();
-        } else {
-            $fields = $config['fields'];
-        }
-
-        Utils::invariant(isset($fields) && is_array($fields), 'Fields must be specified.');
-
-        foreach ($fields as $field) {
-            if (isset($field['isExternal'])) {
-                Utils::invariant(is_bool($field['isExternal']), "Config property 'isExternal' should be a boolean.");
-            }
-
-            if (isset($field['provides'])) {
-                Utils::invariant(is_string($field['provides']), "Config property 'provides' should be a string.");
-            }
-
-            if (isset($field['requires'])) {
-                Utils::invariant(is_string($field['requires']), "Config property 'requires' should be a string.");
-            }
-        }
-    }
-
-    public static function validateKeyFields(array $config)
-    {
-        if (is_callable($config['fields'])) {
-            $fields = $config['fields']();
-        } else {
-            $fields = $config['fields'];
-        }
-
-        Utils::invariant(
-            isset($config['keyFields']) && is_array($config['keyFields']),
-            'Entity key fields must be provided and has to be an array.'
-        );
-
-        foreach ($config['keyFields'] as $keyField) {
-            Utils::invariant(
-                array_key_exists($keyField, $fields),
-                'Entity key refers to a field that does not exist in the fields array.'
-            );
-        }
     }
 
     public static function validateResolveReference(array $config)

--- a/test/EntitiesTest.php
+++ b/test/EntitiesTest.php
@@ -86,55 +86,6 @@ class EntitiesTest extends TestCase
         $this->assertEquals($expectedRef, $actualRef);
     }
 
-    public function testCreatingEntityTypeWithoutKeyFields()
-    {
-        $this->expectException(InvariantViolation::class);
-        $this->expectExceptionMessage('Entity key fields must be provided and has to be an array.');
-
-        $userType = new EntityObjectType([
-            'name' => 'User',
-            'fields' => [
-                'id' => ['type' => Type::int()],
-                'email' => ['type' => Type::string()],
-                'firstName' => ['type' => Type::string()],
-                'lastName' => ['type' => Type::string()]
-            ]
-        ]);
-    }
-
-    public function testCreatingEntityTypeWithNonExistingKeyFields()
-    {
-        $this->expectException(InvariantViolation::class);
-        $this->expectExceptionMessage('Entity key refers to a field that does not exist in the fields array.');
-
-        $userType = new EntityObjectType([
-            'name' => 'User',
-            'keyFields' => ['id', 'email'],
-            'fields' => [
-                'email' => ['type' => Type::string()],
-                'firstName' => ['type' => Type::string()],
-                'lastName' => ['type' => Type::string()]
-            ]
-        ]);
-    }
-
-    public function testCreatingEntityTypeWithInvalidKeyFields()
-    {
-        $this->expectException(InvariantViolation::class);
-        $this->expectExceptionMessage('Entity key fields must be provided and has to be an array.');
-
-        $userType = new EntityObjectType([
-            'name' => 'User',
-            'keyFields' => 'id',
-            'fields' => [
-                'id' => ['type' => Type::int()],
-                'email' => ['type' => Type::string()],
-                'firstName' => ['type' => Type::string()],
-                'lastName' => ['type' => Type::string()]
-            ]
-        ]);
-    }
-
     public function testCreatingEntityRefType()
     {
         $userTypeKeyFields = ['id', 'email'];


### PR DESCRIPTION
### Proposed changes
- Due to complexity of handling recursive types and callables in validation, remove validation at schema instantiation of keyfields and directives. 

⚠️ Validation at this stage is not required, but desirable for ease of future development and should be re-added ⚠️ 

### How to test
- `composer test`

### Unit Tests

- [ ] This PR has unit tests
- [x] This PR does not have unit tests: _why?_
