### PR TITLE
fix(FederatedSchemaPrinter): Skip printing Mutation type on empty

### DIFF
--- a/src/Utils/FederatedSchemaPrinter.php
+++ b/src/Utils/FederatedSchemaPrinter.php
@@ -320,7 +320,7 @@ class FederatedSchemaPrinter
      */
     private static function printObject(ObjectType $type, array $options): string
     {
-        if ($type->name === 'Mutation' && empty($type->getFields())) {
+        if (empty($type->getFields())) {
             return '';
         }
 


### PR DESCRIPTION
### Proposed changes

- Skip printing Mutation type on empty
- Add `extends` to Mutation type

### How to test

- `composer test`
