### PR TITLE
fix: make reference resolver public

### DIFF
--- a/src/Types/EntityObjectType.php
+++ b/src/Types/EntityObjectType.php
@@ -47,7 +47,7 @@ class EntityObjectType extends ObjectType
     private $keyFields;
 
     /** @var callable */
-    private $referenceResolver;
+    public $referenceResolver;
 
     /**
      * @param mixed[] $config


### PR DESCRIPTION
### Proposed changes

- When resolving a federated type, we need to be able to overwrite the `referenceResolver` function which sets the `referenceResolver` property.
- This was mistakenly removed from the previous PR

### How to test
-

### Unit Tests

- [ ] This PR has unit tests
- [ ] This PR does not have unit tests: _why?_
