### PR TITLE
fix(entity-refs): Allow partial references in resolveReference

### DIFF
--- a/src/Types/EntityObjectType.php
+++ b/src/Types/EntityObjectType.php
@@ -113,7 +113,7 @@ class EntityObjectType extends ObjectType
         $refKeys = array_keys($ref);
         $refContainsKeys = !empty(array_intersect($this->getKeyFields(), $refKeys));
 
-        Utils::invariant($refContainsKeys, 'At least one key field must be in the entity reference.');
+        Utils::invariant($refContainsKeys, 'Key fields are missing from the entity reference.');
     }
 
     public static function validateResolveReference(array $config)

--- a/test/EntitiesTest.php
+++ b/test/EntitiesTest.php
@@ -86,6 +86,56 @@ class EntitiesTest extends TestCase
         $this->assertEquals($expectedRef, $actualRef);
     }
 
+    public function testResolvingEntityReferenceWithoutAllKeys()
+    {
+        $expectedRef = [
+            'id' => 1,
+            'email' => 'luke@skywalker.com',
+            'firstName' => 'Luke',
+            'lastName' => 'Skywalker',
+            '__typename' => 'User'
+        ];
+
+        $userType = new EntityObjectType([
+            'name' => 'User',
+            'keyFields' => ['id', 'email'],
+            'fields' => [
+                'id' => ['type' => Type::int()],
+                'email' => ['type' => Type::string()],
+                'firstName' => ['type' => Type::string()],
+                'lastName' => ['type' => Type::string()]
+            ],
+            '__resolveReference' => function () use ($expectedRef) {
+                return $expectedRef;
+            }
+        ]);
+
+        $actualRef = $userType->resolveReference(['email' => 'luke@skywalker.com', '__typename' => 'User']);
+
+        $this->assertEquals($expectedRef, $actualRef);
+    }
+
+    public function testResolvingEntityReferenceWithoutAnyKeys()
+    {
+        $userType = new EntityObjectType([
+            'name' => 'User',
+            'keyFields' => ['id', 'email'],
+            'fields' => [
+                'id' => ['type' => Type::int()],
+                'email' => ['type' => Type::string()],
+                'firstName' => ['type' => Type::string()],
+                'lastName' => ['type' => Type::string()]
+            ],
+            '__resolveReference' => function () {
+                return null;
+            }
+        ]);
+
+        $this->expectException(InvariantViolation::class);
+
+        $userType->resolveReference(['__typename' => 'User']);
+    }
+
     public function testCreatingEntityRefType()
     {
         $userTypeKeyFields = ['id', 'email'];


### PR DESCRIPTION
### Overview

While resolving references (`__resolveReference`), the `EntityRefObjectType` validates that all fields declared in the `keyFields` config array are provided and throws an `InvariantViolation` otherwise. However, while testing integration with https://github.com/apollographql/apollo-federation-subgraph-compatibility, the Apollo Gateway providing a subgraph with a partial reference is a valid case.

Type definition:

```gql
type Product @key(fields: "id") @key(fields: "sku package") @key(fields: "sku variation { id }") {
  id: ID!
  sku: String
  package: String
  variation: ProductVariation
  dimensions: ProductDimension
  createdBy: User @provides(fields: "totalProductsCreated")
}
```

Test query:

```gql
query  {
  _entities(representations: [{ 
    sku: "studio",
    variation: { id: "platform" },
    __typename: "Product"
  }]) {
    ... on Product {
      sku
    }
  }
}
```

### Proposed changes

- Update the `EntityRefObjectType` to only require at least one key instead of all of them.

### How to test

- `composer test`

### Unit Tests

- [x] This PR has unit tests
- [ ] This PR does not have unit tests
