### PR TITLE
fix: ensure default directives do not get replaced by custom directives

### DIFF
--- a/src/FederatedSchema.php
+++ b/src/FederatedSchema.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Apollo\Federation;
 
-use GraphQL\GraphQL;
-use GraphQL\Type\Definition\Directive;
 use GraphQL\Type\Schema;
 use GraphQL\Type\Definition\CustomScalarType;
+use GraphQL\Type\Definition\Directive;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\UnionType;
 use GraphQL\Type\Definition\Type;

--- a/src/FederatedSchema.php
+++ b/src/FederatedSchema.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Apollo\Federation;
 
+use GraphQL\GraphQL;
+use GraphQL\Type\Definition\Directive;
 use GraphQL\Type\Schema;
 use GraphQL\Type\Definition\CustomScalarType;
 use GraphQL\Type\Definition\ObjectType;
@@ -63,7 +65,7 @@ class FederatedSchema extends Schema
     public function __construct($config)
     {
         $this->entityTypes = $this->extractEntityTypes($config);
-        $this->entityDirectives = Directives::getDirectives();
+        $this->entityDirectives = array_merge(Directives::getDirectives(), Directive::getInternalDirectives());
 
         $config = array_merge($config, $this->getEntityDirectivesConfig($config), $this->getQueryTypeConfig($config));
 

--- a/test/SchemaTest.php
+++ b/test/SchemaTest.php
@@ -62,6 +62,12 @@ class SchemaTest extends TestCase
         $this->assertArrayHasKey('external', $directives);
         $this->assertArrayHasKey('provides', $directives);
         $this->assertArrayHasKey('requires', $directives);
+
+        // These are the default directives, which should not be replaced
+        // https://www.apollographql.com/docs/apollo-server/schema/directives#default-directives
+        $this->assertArrayHasKey('include', $directives);
+        $this->assertArrayHasKey('skip', $directives);
+        $this->assertArrayHasKey('deprecated', $directives);
     }
 
     public function testServiceSdl()


### PR DESCRIPTION
### Proposed changes
- This PR fixes a bug where our custom directives for federation were replacing the default directives, making queries which included `include` or `skip` not work correctly - the underlying `webonyx/graphql-php` library would throw this error: `"Unknown directive \"include\"`. 
- By merging the custom directives with the standard ones, we now have all of the required directives. 

### How to test
- In addition to unit tests, I tested locally with a federated schema. This fix allowed a query which used `@include` across a federated schema to properly resolve. 

Can also confirm by running this query to see the directives:
```graphql
query{
  __schema{
    directives{
      name
    }
  }
}
```

before:
```json
{
  "data": {
    "__schema": {
      "directives": [
        {
          "name": "key"
        },
        {
          "name": "external"
        },
        {
          "name": "requires"
        },
        {
          "name": "provides"
        }
      ]
    }
  }
}
```

with the fix:
```json
{
  "data": {
    "__schema": {
      "directives": [
        {
          "name": "key"
        },
        {
          "name": "external"
        },
        {
          "name": "requires"
        },
        {
          "name": "provides"
        },
        {
          "name": "include"
        },
        {
          "name": "skip"
        },
        {
          "name": "deprecated"
        }
      ]
    }
  }
}
```

### Unit Tests

- [x] This PR has unit tests
- [ ] This PR does not have unit tests: _why?_
