### PR TITLE
feat: entity type customization, type loader support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ $query = 'query GetServiceSDL { _service { sdl } }';
 $result = GraphQL::executeQuery($schema, $query);
 ```
 
-#### config
+#### Config
 
 The config parameter for the `FederatedSchema` object is entirely compatible with the `Schema` config argument. On top of this, we support the following optional parameters:
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ $query = 'query GetServiceSDL { _service { sdl } }';
 $result = GraphQL::executeQuery($schema, $query);
 ```
 
+#### config
+
+The config parameter for the `FederatedSchema` object is entirely compatible with the `Schema` config argument. On top of this, we support the following optional parameters:
+
+1. `entityTypes` - the entity types (which extend `EntityObjectType`) which will form the `_Entity` type on the federated schema. If not provided, the Schema will scan the `Query` type tree for all types extending `EntityObjectType`.
+
 ## Disclaimer
 
 Documentation in this project include content quoted directly from the [Apollo official documentation](https://www.apollographql.com/docs) to reduce redundancy.

--- a/src/FederatedSchema.php
+++ b/src/FederatedSchema.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Apollo\Federation;
 
+use Apollo\Federation\Types\AnyType;
 use GraphQL\Type\Schema;
-use GraphQL\Type\Definition\CustomScalarType;
 use GraphQL\Type\Definition\Directive;
 use GraphQL\Type\Definition\ObjectType;
-use GraphQL\Type\Definition\UnionType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Utils\TypeInfo;
 use GraphQL\Utils\Utils;
 
 use Apollo\Federation\Types\EntityObjectType;
-use Apollo\Federation\Utils\FederatedSchemaPrinter;
+use Apollo\Federation\Types\EntityUnionType;
+use Apollo\Federation\Types\ServiceDefinitionType;
 
 /**
  * A federated GraphQL schema definition (see [related docs](https://www.apollographql.com/docs/apollo-server/federation/introduction))
@@ -61,12 +61,24 @@ class FederatedSchema extends Schema
     /** @var Directive[] */
     protected $entityDirectives;
 
+    protected ServiceDefinitionType $serviceDefinitionType;
+    protected EntityUnionType $entityUnionType;
+    protected AnyType $anyType;
+
     public function __construct($config)
     {
-        $this->entityTypes = $this->extractEntityTypes($config);
+        $this->entityTypes = $config['entityTypes'] ?? $this->extractEntityTypes($config);
         $this->entityDirectives = array_merge(Directives::getDirectives(), Directive::getInternalDirectives());
+        
+        $this->serviceDefinitionType = new ServiceDefinitionType($this);
+        $this->entityUnionType = new EntityUnionType($this->entityTypes);
+        $this->anyType = new AnyType();
 
-        $config = array_merge($config, $this->getEntityDirectivesConfig($config), $this->getQueryTypeConfig($config));
+        $config = array_merge($config, 
+            $this->getEntityDirectivesConfig($config), 
+            $this->getQueryTypeConfig($config),
+            $this->supplementTypeLoader($config)
+        );
 
         parent::__construct($config);
     }
@@ -121,24 +133,42 @@ class FederatedSchema extends Schema
         ];
     }
 
+    /**
+     * Add type loading functionality for the types required for the federated schema to function.
+     */
+    private function supplementTypeLoader(array $config): array
+    {
+        if (!array_key_exists('typeLoader', $config) || !is_callable($config['typeLoader'])) {
+            return [];
+        }
+
+        return [
+            'typeLoader' => function ($typeName) use ($config) {
+                $map = $this->builtInTypeMap();
+                if (array_key_exists($typeName, $map)) {
+                    return $map[$typeName];
+                }
+
+                return $config['typeLoader']($typeName);
+            }
+        ];
+    }
+
+    private function builtInTypeMap(): array 
+    {
+        return [
+            EntityUnionType::getTypeName() => $this->entityUnionType,
+            ServiceDefinitionType::getTypeName() => $this->serviceDefinitionType,
+            AnyType::getTypeName() => $this->anyType
+        ];
+    }
+
     /** @var array */
     private function getQueryTypeServiceFieldConfig(): array
     {
-        $serviceType = new ObjectType([
-            'name' => '_Service',
-            'fields' => [
-                'sdl' => [
-                    'type' => Type::string(),
-                    'resolve' => function () {
-                        return FederatedSchemaPrinter::doPrint($this);
-                    }
-                ]
-            ]
-        ]);
-
         return [
             '_service' => [
-                'type' => Type::nonNull($serviceType),
+                'type' => Type::nonNull($this->serviceDefinitionType),
                 'resolve' => function () {
                     return [];
                 }
@@ -153,24 +183,12 @@ class FederatedSchema extends Schema
             return [];
         }
 
-        $entityType = new UnionType([
-            'name' => '_Entity',
-            'types' => array_values($this->getEntityTypes())
-        ]);
-
-        $anyType = new CustomScalarType([
-            'name' => '_Any',
-            'serialize' => function ($value) {
-                return $value;
-            }
-        ]);
-
         return [
             '_entities' => [
-                'type' => Type::listOf($entityType),
+                'type' => Type::listOf($this->entityUnionType),
                 'args' => [
                     'representations' => [
-                        'type' => Type::nonNull(Type::listOf(Type::nonNull($anyType)))
+                        'type' => Type::nonNull(Type::listOf(Type::nonNull($this->anyType)))
                     ]
                 ],
                 'resolve' => function ($root, $args, $context, $info) use ($config) {

--- a/src/FederatedSchema.php
+++ b/src/FederatedSchema.php
@@ -65,6 +65,12 @@ class FederatedSchema extends Schema
     protected EntityUnionType $entityUnionType;
     protected AnyType $anyType;
 
+    /**
+     * 
+     * We will provide the parts that we need to operate against.
+     * 
+     * @param array{?entityTypes: array<EntityObjectType>, ?typeLoader: callable, query: array} $config
+     */
     public function __construct($config)
     {
         $this->entityTypes = $config['entityTypes'] ?? $this->lazyEntityTypeExtractor($config);

--- a/src/Types/AnyType.php
+++ b/src/Types/AnyType.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apollo\Federation\Types;
+
+use GraphQL\Type\Definition\CustomScalarType;
+
+/**
+ * Simple representation of an agnostic scalar value.
+ */
+class AnyType extends CustomScalarType
+{
+    public function __construct()
+    {
+        $config = [
+            'name' => self::getTypeName(),
+            'serialize' => function ($value) {
+                return $value;
+            }
+        ];
+        parent::__construct($config);
+    }
+
+    public static function getTypeName(): string
+    {
+        return '_Any';
+    }
+}

--- a/src/Types/EntityUnionType.php
+++ b/src/Types/EntityUnionType.php
@@ -13,13 +13,16 @@ class EntityUnionType extends UnionType
 {
 
     /**
-     * @param array $entityTypes all entity types.
+     * @param array|callable $entityTypes all entity types or a callable to retrieve them
      */
-    public function __construct(array $entityTypes)
+    public function __construct($entityTypes)
     {
         $config = [
             'name' => self::getTypeName(),
-            'types' => array_values($entityTypes)
+            'types' => is_callable($entityTypes) 
+                ? fn () => array_values($entityTypes())
+                : array_values($entityTypes)
+                
         ];
         parent::__construct($config);
     }

--- a/src/Types/EntityUnionType.php
+++ b/src/Types/EntityUnionType.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apollo\Federation\Types;
+
+use GraphQL\Type\Definition\UnionType;
+
+/**
+ * The union of all entities defined within this schema.
+ */
+class EntityUnionType extends UnionType
+{
+
+    /**
+     * @param array $entityTypes all entity types.
+     */
+    public function __construct(array $entityTypes)
+    {
+        $config = [
+            'name' => self::getTypeName(),
+            'types' => array_values($entityTypes)
+        ];
+        parent::__construct($config);
+    }
+
+    public static function getTypeName(): string
+    {
+        return '_Entity';
+    }
+}

--- a/src/Types/ServiceDefinitionType.php
+++ b/src/Types/ServiceDefinitionType.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apollo\Federation\Types;
+
+use Apollo\Federation\Utils\FederatedSchemaPrinter;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Schema;
+
+/**
+ * The type of the service definition required for federated schemas.
+ */
+class ServiceDefinitionType extends ObjectType
+{
+
+    /**
+     * @param Schema $schema - the schemas whose SDL should be printed.
+     */
+    public function __construct(Schema $schema)
+    {
+        $config = [
+            'name' => self::getTypeName(),
+            'fields' => [
+                'sdl' => [
+                    'type' => Type::string(),
+                    'resolve' => fn () => FederatedSchemaPrinter::doPrint($schema)
+                ]     
+            ]
+        ];
+        parent::__construct($config);
+    }
+
+    public static function getTypeName(): string
+    {
+        return '_Service';
+    }
+}

--- a/test/SchemaTest.php
+++ b/test/SchemaTest.php
@@ -8,11 +8,9 @@ use PHPUnit\Framework\TestCase;
 use Spatie\Snapshots\MatchesSnapshots;
 
 use GraphQL\GraphQL;
-use GraphQL\Type\Definition\Type;
 use GraphQL\Utils\SchemaPrinter;
 
 use Apollo\Federation\Tests\StarWarsSchema;
-use Apollo\Federation\Tests\DungeonsAndDragonsSchema;
 
 class SchemaTest extends TestCase
 {
@@ -83,6 +81,14 @@ class SchemaTest extends TestCase
     public function testSchemaSdl()
     {
         $schema = StarWarsSchema::getEpisodesSchema();
+        $schemaSdl = SchemaPrinter::doPrint($schema);
+
+        $this->assertMatchesSnapshot($schemaSdl);
+    }
+
+    public function testSchemaSdlForProvidedEntities()
+    {
+        $schema = StarWarsSchema::getEpisodesSchemaWithProvidedEntities();
         $schemaSdl = SchemaPrinter::doPrint($schema);
 
         $this->assertMatchesSnapshot($schemaSdl);

--- a/test/__snapshots__/SchemaTest__testSchemaSdlForProvidedEntities__1.txt
+++ b/test/__snapshots__/SchemaTest__testSchemaSdlForProvidedEntities__1.txt
@@ -1,0 +1,42 @@
+directive @key(fields: String!) on OBJECT | INTERFACE
+
+directive @external on FIELD_DEFINITION
+
+directive @requires(fields: String!) on FIELD_DEFINITION
+
+directive @provides(fields: String!) on FIELD_DEFINITION
+
+"""A character in the Star Wars Trilogy"""
+type Character {
+  id: Int!
+  name: String!
+  locations: [Location]!
+}
+
+"""A film in the Star Wars Trilogy"""
+type Episode {
+  id: Int!
+  title: String!
+  characters: [Character!]!
+}
+
+"""A location in the Star Wars Trilogy"""
+type Location {
+  id: Int!
+  name: String!
+}
+
+type Query {
+  episodes: [Episode!]!
+  deprecatedEpisodes: [Episode!]! @deprecated(reason: "Because you should use the other one.")
+  _service: _Service!
+  _entities(representations: [_Any!]!): [_Entity]
+}
+
+scalar _Any
+
+union _Entity = Episode | Character | Location
+
+type _Service {
+  sdl: String
+}


### PR DESCRIPTION
### Proposed changes
- Provide support for the `typeLoader` config option by exposing the types added for the FederatedSchema (namely, `_Service`, `_Entity`, `_Any`
- Also Provides two different ways that we could try to prevent the `EntityUnionType` from doing an entire type tree scan
  - Exposes the ability to provide a pre existing list of entity types (and thus bypass the type scan
  - Adjusted the fallback behavior to make the entity union type `types` field a callable so that theoretically the underlying entity types (and therefore the type scan) only happens on analysis/interpretation of the `_Entity` type. 
  - We will have to evaluate which effect gives more of the desired performance improvement.  

### How to test

-

### Unit Tests

- [x] This PR has unit tests
- [ ] This PR does not have unit tests: _why?_
